### PR TITLE
Default to read from stdin if no file argument is passed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod ir441;
 use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
+use std::io::{self, BufReader};
 use std::path::Path;
 use std::collections::{HashMap,BTreeMap};
 
@@ -58,17 +59,21 @@ fn check_warnings(prog: &IRProgram) {
 
 fn main() -> Result<(),Box<dyn std::error::Error>> {
     let cmd = std::env::args().nth(1).expect("need subcommand [check|exec|trace|perf]");
-    let txt = std::env::args().nth(2).expect("441 IR code to process");
-
-    let libfile = Path::new(&txt);
-    let display = libfile.display();
-
-    let mut file = match File::open(&txt) {
-        Err(why) => panic!("Couldn't open {}: {}", display, why),
-        Ok(file) => file,
+    let txt = std::env::args().nth(2);
+    let mut reader: Box<dyn BufRead> = match txt {
+        None => Box::new(BufReader::new(io::stdin())),
+        Some(filepath) => {
+            let libfile = Path::new(&filepath);
+            let display = libfile.display();
+            match File::open(&filepath) {
+                Err(why) => panic!("Couldn't open {}: {}", display, why),
+                Ok(file) => Box::new(BufReader::new(file)),
+            }
+        }
     };
+
     let mut bytes : Vec<u8> = vec![];
-    file.read_to_end(&mut bytes)?; 
+    reader.read_to_end(&mut bytes)?; 
     let (_leftover,prog) = parse_program(&bytes[..]).finish().map_err(|nom::error::Error { input, code: _ }| from_utf8(input).unwrap())?;
     let cmd_str = cmd.as_str();
 


### PR DESCRIPTION
Often I'd like to write some example programs for testing and would like to run these through my compiler and then through the ir441 tool. Sometimes if I change something in the compiler I'd like to regenerate the IR output and re-run it again through ir441 to make sure it still works. However this can get tedious since ir441 requires a filename as input, meaning I end up generating a ton of temp IR files and have to clean them up afterwards.

Ideally I'd like to _pipe_ in the output from my compiler into ir441 to avoid this, i.e. `./comp < test.441 | ir441 perf`. This would save one extra command per test and avoid needing to create all of the IR files.

The pull request makes the changes necessary to default to reading from stdin if no filename is passed. Otherwise the logic is the same as before.

As a disclaimer I have not used Rust before so I don't know if my code is "good" in terms of style. I pulled mainly from this [StackOverflow post](https://stackoverflow.com/questions/36088116/how-to-do-polymorphic-io-from-either-a-file-or-stdin-in-rust). In testing this changes seems to work. Feel free to adjust the code if you think there is a better way to do this.